### PR TITLE
Refactor email utility to support multiple providers

### DIFF
--- a/break-away/src/actions/send-email-action.ts
+++ b/break-away/src/actions/send-email-action.ts
@@ -9,6 +9,7 @@ export const sendEmailMessage = async(
 
   const checkinFormLink = process.env.CHECKIN_FORM_LINK as string;
   const result = await EmailUtility.sendEmail(
+    "sendgrid",
     "BreakAway Notification", // Sender name
     process.env.VERIFIED_SENDER_EMAIL as string, // Sender address
     [

--- a/break-away/src/decision-rules/screen-break-email.dr.ts
+++ b/break-away/src/decision-rules/screen-break-email.dr.ts
@@ -1,8 +1,7 @@
 import { DecisionRuleRegistration, JEvent, JUser, Log, StepReturnResult } from "@just-in/core";
 import { MessageBank } from "../lib/message-bank";
-import { sendEmailMessage } from "../actions/send-email-action";
 import { sendGridSendEmail } from "../lib/sendgrid/send-mail";
-
+import { EmailUtility } from "../lib/email-utility"
 const name: string =  'sendEmailDecisionRule';
 const minutesBetweenEmails: number = 2;
 const probabilityOfPersuasiveEmail: number = 0.5;
@@ -70,9 +69,12 @@ const doAction = async (
   if (action === Action.SendPersuasiveEmail) {
     const tag = ContentTag.Persuasive;
     interventionMessage = MessageBank.getMessageRandomlyByTag(tag);
-    const sendStatus = await sendGridSendEmail(
-      user.attributes.email, 
-      "BreakAway Notification", 
+    const sendStatus = await EmailUtility.sendEmail(
+      "mailjet",
+      "BreakAway Notification",
+      process.env.VERIFIED_SENDER_EMAIL as string,
+      [{ name: user.attributes.name, address: user.attributes.email }],
+      "BreakAway Notification",
       interventionMessage,
       `<p>Hi ${user.attributes.name}</p><p>${interventionMessage}</p><p>Check-in here: <a href="${checkinFormLink.replace('[email]', user.attributes.email)}">Google Form</a></p>`);
 
@@ -89,12 +91,22 @@ const doAction = async (
   } else {
     const tag = ContentTag.Generic;
     interventionMessage = MessageBank.getMessageRandomlyByTag(tag);
+        const sendStatus = await EmailUtility.sendEmail(
+      "mailjet",
+      "BreakAway Notification",
+      process.env.VERIFIED_SENDER_EMAIL as string,
+      [{ name: user.attributes.name, address: user.attributes.email }],
+      "BreakAway Notification",
+      interventionMessage,
+      `<p>Hi ${user.attributes.name}</p><p>${interventionMessage}</p><p>Check-in here: <a href="${checkinFormLink.replace('[email]', user.attributes.email)}">Google Form</a></p>`);
+
+    /*
     const sendStatus = await sendGridSendEmail(
       user.attributes.email, 
       "BreakAway Notification", 
       interventionMessage,
       `<p>Hi ${user.attributes.name}</p><p>${interventionMessage}</p><p>Check-in here: <a href="${checkinFormLink.replace('[email]', user.attributes.email)}">Google Form</a></p>`);
-
+    */
     returnObject = {
       status: "success",
       result: {

--- a/break-away/src/lib/__tests__/test_email.ts
+++ b/break-away/src/lib/__tests__/test_email.ts
@@ -1,7 +1,7 @@
 import { EmailUtility } from "../email-utility";
 import { config } from "dotenv";
 config({ quiet: true });
-EmailUtility.sendEmail("BreakAway Notification", process.env.VERIFIED_SENDER_EMAIL as string, [{ name: "Test Recipient", address: process.env.TEST_RECIPIENT_EMAIL_1 as string }], "Break Away", "Break Away Test").then((result) => {
+EmailUtility.sendEmail("sendgrid", "BreakAway Notification", process.env.VERIFIED_SENDER_EMAIL as string, [{ name: "Test Recipient", address: process.env.TEST_RECIPIENT_EMAIL_1 as string }], "Break Away", "Break Away Test").then((result) => {
   console.log("Email sent successfully:", result);
 }).catch((error) => {
   console.error("Error sending email:", error);


### PR DESCRIPTION
EmailUtility.sendEmail now accepts a provider argument to support both SendGrid and Mailjet. Updated usages in actions, decision rules, and tests to specify the provider. Improved SendGrid payload construction and logging, and replaced direct SendGrid calls in decision rules with EmailUtility for consistency.