### PR TITLE
Remove unnecessary logging in email decision rule

### DIFF
--- a/break-away/src/decision-rules/screen-break-email.dr.ts
+++ b/break-away/src/decision-rules/screen-break-email.dr.ts
@@ -29,6 +29,9 @@ const shouldActivate = async (
   if (roundedMinutes % minutesBetweenEmails === 0) {
     status = 'success';
   }
+  else {
+    //console.log(`${event.generatedTimestamp?.toISOString()} - ${name} did not activate for user: ${user.uniqueIdentifier} (${user.attributes.name})`);
+  }
 
   return { status: status, result: {} };
 };


### PR DESCRIPTION
Eliminated a console.log statement that logged when the screen break email rule did not activate. The framework already output message that is similar in meaning.